### PR TITLE
Add auth for admin and auth frontend

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -7,14 +7,8 @@ User = get_user_model()
 
 
 class RegisterSerializer(serializers.ModelSerializer):
-    email = serializers.EmailField(
-        required=True,
-        validators=[UniqueValidator(queryset=User.objects.all())]
-    )
-    username = serializers.CharField(
-        required=True,
-        validators=[UniqueValidator(queryset=User.objects.all())]
-    )
+    email = serializers.EmailField(required=True)
+    username = serializers.CharField(required=True)
     
     password = serializers.CharField(write_only=True, required=True, validators=[validate_password])
 
@@ -25,6 +19,15 @@ class RegisterSerializer(serializers.ModelSerializer):
             "first_name", "last_name", "phone_number", "gender",
             "date_of_birth", "address", "avatar",
         )
+
+    def validate(self, attrs):
+        if User.objects.filter(username=attrs['username']).exists():
+            raise serializers.ValidationError("Username này đã tồn tại.")
+        
+        if User.objects.filter(email=attrs['email']).exists():
+            raise serializers.ValidationError("Email này đã được sử dụng.")
+
+        return attrs
 
     def create(self, validated_data):
         user = User.objects.create_user(**validated_data)
@@ -50,5 +53,28 @@ class LoginSerializer(serializers.Serializer):
             msg = 'Phải bao gồm "username" và "password".'
             raise serializers.ValidationError(msg, code='authorization')
 
+        attrs['user'] = user
+        return attrs
+
+class AdminLoginSerializer(serializers.Serializer):
+    username = serializers.CharField()
+    password = serializers.CharField(write_only=True)
+
+    def validate(self, attrs):
+        username = attrs.get('username')
+        password = attrs.get('password')
+
+        if not (username and password):
+            raise serializers.ValidationError("Phải bao gồm 'username' và 'password'.")
+
+        user = authenticate(request=self.context.get('request'), 
+                              username=username, password=password)
+
+        if not user:
+            raise serializers.ValidationError("Thông tin đăng nhập không hợp lệ.")
+
+        if not user.is_superuser:
+            raise serializers.ValidationError("Truy cập bị từ chối. Cần có quyền admin.")
+        
         attrs['user'] = user
         return attrs

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import RegisterView, LoginView, LogoutView
+from .views import RegisterView, LoginView, LogoutView, AdminLoginView
 
 urlpatterns = [
     path("api/register/", RegisterView.as_view(), name="register"),
     path("api/login/", LoginView.as_view(), name="login"),
     path("api/logout/", LogoutView.as_view(), name="logout"),
+    path("api/agrihcmAdmin/login/", AdminLoginView.as_view(), name="admin_login"),
 ]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -3,7 +3,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework_simplejwt.tokens import RefreshToken
-from .serializers import RegisterSerializer, LoginSerializer
+from .serializers import RegisterSerializer, LoginSerializer, AdminLoginSerializer
+from django.contrib.auth import authenticate
 
 
 class RegisterView(generics.CreateAPIView):
@@ -28,7 +29,7 @@ class LoginView(APIView):
                 "username": user.username,
                 "email": user.email,
             },
-        })
+        }, status=status.HTTP_200_OK)
 
 
 class LogoutView(APIView):
@@ -42,3 +43,25 @@ class LogoutView(APIView):
             return Response({"message": "Logout successful"}, status=status.HTTP_200_OK)
         except Exception:
             return Response({"error": "Invalid token"}, status=status.HTTP_400_BAD_REQUEST)
+
+
+class AdminLoginView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = AdminLoginSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.validated_data["user"]
+
+        refresh = RefreshToken.for_user(user)
+        return Response({
+            'message': 'Admin login successful',
+            'refresh': str(refresh),
+            'access': str(refresh.access_token),
+            'user': {
+                'id': user.id,
+                'username': user.username,
+                'email': user.email,
+                'is_superuser': user.is_superuser
+            }
+        }, status=status.HTTP_200_OK)

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     path("", include("blogs.urls")),
     path("", include("accounts.urls")),
     path("", include("products.urls")),
+    path("", include("users.urls")),
 ]

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'email', 'first_name', 'last_name', 'avatar']

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import UserView
+
+urlpatterns = [
+    path("api/users/me/", UserView.as_view(), name="current_user_info")
+]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,3 +1,12 @@
-from django.shortcuts import render
+from .serializers import UserSerializer
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
+from rest_framework.response import Response
 
-# Create your views here.
+class UserView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        serializer = UserSerializer(request.user)
+        return Response(serializer.data)
+   

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,19 +9,22 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-navigation-menu": "1.2.14",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
-    "class-variance-authority": "0.7.1",
-    "clsx": "2.1.1",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "isomorphic-dompurify": "2.28.0",
-    "lucide-react": "0.544.0",
+    "jose": "^6.1.0",
+    "lucide-react": "^0.544.0",
     "next": "15.5.4",
     "next-seo": "6.8.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "tailwind-merge": "3.3.1"
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "3",
@@ -35,7 +38,7 @@
     "eslint-config-next": "15.5.4",
     "postcss": "8.5.6",
     "tailwindcss": "4.1.13",
-    "tw-animate-css": "1.4.0",
+    "tw-animate-css": "^1.4.0",
     "typescript": "5"
   }
 }

--- a/frontend/src/app/agrihcmAdmin/actions.ts
+++ b/frontend/src/app/agrihcmAdmin/actions.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { fetchApi } from "@/lib/api";
+import { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
+
+interface ActionState {
+  message: string;
+  success?: boolean;
+}
+
+interface LoginResponse {
+  access: string;
+  refresh: string;
+  user: {
+    id: number;
+    username: string;
+    email: string;
+    is_superuser: boolean;
+  };
+}
+
+function setAuthCookies(
+  cookieStore: ReadonlyRequestCookies,
+  accessToken: string,
+  refreshToken: string
+) {
+
+  const options = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    path: "/",
+  };
+
+  cookieStore.set("accessToken", accessToken, { ...options, maxAge: 60 * 60 });
+  cookieStore.set("refreshToken", refreshToken, {
+    ...options,
+    maxAge: 60 * 60 * 24 * 7,
+  });
+}
+
+export async function adminLogin(prevState: ActionState, formData: FormData): Promise<ActionState> {
+  const data = Object.fromEntries(formData);
+  
+  try {
+    const response = (await fetchApi("api/agrihcmAdmin/login/", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })) as LoginResponse;
+    const cookieStore = await cookies();
+    setAuthCookies(cookieStore, response.access, response.refresh);
+    return { success: true, message: 'Admin login successful' };
+
+  } catch (error) {
+    console.error("Admin login failed:", error);
+    if (error instanceof Error) {
+      return { success: false, message: error.message };
+    }
+    return { success: false, message: "An unknown error occurred during login." };
+  }
+}

--- a/frontend/src/app/agrihcmAdmin/login/page.tsx
+++ b/frontend/src/app/agrihcmAdmin/login/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+import { adminLogin } from "../actions";
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label } from "@/components/ui";
+import { useActionState, useEffect } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter } from "next/navigation";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" className="w-full" disabled={pending}>
+      {pending ? "Signing In..." : "Sign In"}
+    </Button>
+  );
+}
+
+export default function LoginPage() {
+  const [state, formAction] = useActionState(adminLogin, { message: "" });
+  const { checkUserSession } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (state.success) {
+      checkUserSession().then(() => {
+        router.push('/agrihcmAdmin');
+      });
+    }
+  }, [state, checkUserSession, router]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Sign in for ADMIN</CardTitle>
+          <CardDescription>Enter your username to sign in to ADMIN account.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form action={formAction} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="username">Username</Label>
+              <Input id="username" name="username" placeholder="yourusername" required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input id="password" name="password" type="password" required />
+            </div>
+            
+            {!state.success && state?.message && (
+              <p className="text-sm text-destructive">{state.message}</p>
+            )}
+
+            <SubmitButton />
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/app/agrihcmAdmin/page.tsx
+++ b/frontend/src/app/agrihcmAdmin/page.tsx
@@ -1,0 +1,9 @@
+
+
+export default function adminPage() {
+  return (
+    <>
+      <h1>WELCOME TO ADMIN</h1>
+    </>
+  )
+}

--- a/frontend/src/app/auth/actions.ts
+++ b/frontend/src/app/auth/actions.ts
@@ -1,0 +1,119 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { fetchApi } from "@/lib/api";
+import { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
+
+interface ActionState {
+  message: string;
+  success?: boolean;
+}
+
+interface LoginResponse {
+  access: string;
+  refresh: string;
+  user: {
+    id: number;
+    username: string;
+    email: string;
+  };
+}
+
+function setAuthCookies(
+  cookieStore: ReadonlyRequestCookies,
+  accessToken: string,
+  refreshToken: string
+) {
+
+  const options = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    path: "/",
+  };
+
+  cookieStore.set("accessToken", accessToken, { ...options, maxAge: 60 * 60 });
+  cookieStore.set("refreshToken", refreshToken, {
+    ...options,
+    maxAge: 60 * 60 * 24 * 7,
+  });
+}
+
+export async function apiLogin(prevState: ActionState, formData: FormData): Promise<ActionState> {
+  const data = Object.fromEntries(formData);
+  
+  try {
+    const response = (await fetchApi("api/login/", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })) as LoginResponse;
+
+    const cookieStore = await cookies();
+
+    setAuthCookies(cookieStore, response.access, response.refresh);
+
+    return { success: true, message: 'Login successful' };
+
+  } catch (error) {
+    console.error("Login failed:", error);
+    if (error instanceof Error) {
+      return { success: false, message: error.message };
+    }
+    return { success: false, message: "An unknown error occurred during login." };
+  }
+}
+
+export async function register(prevState: ActionState, formData: FormData): Promise<ActionState> {
+  const data = Object.fromEntries(formData);
+
+  if (data.password !== data.confirm_password) {
+      return { message: "Passwords do not match." };
+  }
+
+  try {
+      const { confirm_password, ...payload } = data;
+      await fetchApi("api/register/", {
+          method: "POST",
+          body: JSON.stringify(payload),
+      });
+  } catch (error: unknown) {
+      console.error("Registration failed:", error);
+      if (error instanceof Error) {
+        return { message: error.message };
+      }
+      return { message: "An unknown error occurred during registration." };
+  }
+  
+  redirect("/auth/login");
+}
+
+export async function apiLogout() {
+  console.log('start logout')
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+  const refreshToken = cookieStore.get('refreshToken')?.value;
+
+  if (!accessToken) {
+    console.log("No accessToken");
+  }
+
+  try {
+    await fetchApi("api/logout/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        refresh: refreshToken
+      })
+    });
+  } catch (error) {
+    console.error("Logout failed:", error);
+  }
+
+  cookieStore.delete('accessToken');
+  cookieStore.delete('refreshToken');
+  redirect('/');
+}

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+import Link from "next/link";
+import { apiLogin } from "../actions";
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label } from "@/components/ui";
+import { useActionState, useEffect } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter } from "next/navigation";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" className="w-full" disabled={pending}>
+      {pending ? "Đang đăng nhập..." : "Đăng nhập"}
+    </Button>
+  );
+}
+
+export default function LoginPage() {
+  const [state, formAction] = useActionState(apiLogin, { message: "" });
+  const { checkUserSession } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (state.success) {
+      checkUserSession().then(() => {
+        router.push('/blog'); 
+      });
+    }
+  }, [state, checkUserSession, router]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Đăng nhập</CardTitle>
+          <CardDescription>Nhập username để đăng nhập vào tài khoản.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form action={formAction} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="username">Username</Label>
+              <Input id="username" name="username" placeholder="username của bạn" required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Mật khẩu</Label>
+              <Input id="password" name="password" type="password" required />
+            </div>
+            
+            {!state.success && state?.message && (
+              <p className="text-sm text-destructive">{state.message}</p>
+            )}
+
+            <SubmitButton />
+          </form>
+          <div className="mt-4 text-center text-sm">
+            {"Chưa có tài khoản? "}
+            <Link href="/auth/signup" className="underline">
+              Đăng ký
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/app/auth/signup/page.tsx
+++ b/frontend/src/app/auth/signup/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+import Link from "next/link";
+import { register } from "../actions";
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label } from "@/components/ui";
+import { useState, useEffect, useActionState } from "react";
+
+function SubmitButton({ clientError }: { clientError: string }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" className="w-full" disabled={pending || !!clientError}>
+      {pending ? "Đang tạo tài khoản..." : "Tạo tài khoản"}
+    </Button>
+  );
+}
+
+
+export default function RegisterPage() {
+  const [state, formAction] = useActionState(register, { message: "" });
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [clientError, setClientError] = useState('');
+
+  useEffect(() => {
+    if (password && confirmPassword && password !== confirmPassword) {
+      setClientError("Passwords do not match.");
+    } else {
+      setClientError('');
+    }
+  }, [password, confirmPassword]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background py-8">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Đăng ký</CardTitle>
+          <CardDescription>Nhập thông tin của bạn để tạo tài khoản.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form action={formAction} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="username">Username</Label>
+              <Input id="username" name="username" placeholder="username của bạn" required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" name="email" type="email" placeholder="m@example.com" required />
+            </div>
+            
+            <div className="space-y-2">
+              <Label htmlFor="password">Mật khẩu</Label>
+              <Input 
+                id="password" 
+                name="password" 
+                type="password" 
+                required 
+                value={password}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirm_password">Xác nhận mật khẩu</Label>
+              <Input 
+                id="confirm_password" 
+                name="confirm_password" 
+                type="password" 
+                required 
+                value={confirmPassword}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setConfirmPassword(e.target.value)}
+              />
+            </div>
+            
+            {(clientError || state?.message) && (
+              <p className="text-sm text-destructive">
+                {clientError || state.message}
+              </p>
+            )}
+
+            <SubmitButton clientError={clientError} />
+          </form>
+          <div className="mt-4 text-center text-sm">
+            {"Đã có tài khoản? "}
+            <Link href="/auth/login" className="underline">
+              Đăng nhập
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import { Navbar } from "@/components/navbar";
+import LayoutWrapper from "@/components/layoutWrapper";
+import { AuthProvider } from "@/contexts/AuthContext";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
@@ -39,8 +40,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Navbar />
-        {children}
+        <AuthProvider>
+          <LayoutWrapper>
+            {children}
+          </LayoutWrapper>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/layoutWrapper.tsx
+++ b/frontend/src/components/layoutWrapper.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
+import Navbar from "./navbar";
+
+export default function LayoutWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  console.log(`pathname: ${pathname}`);
+  const [showNavbar, setShowNavbar] = useState(true);
+
+  useEffect(() => {
+    if (pathname.includes("/agrihcmAdmin")) {
+      setShowNavbar(false);
+    } else {
+      setShowNavbar(true);
+    }
+  }, [pathname]);
+
+  return (
+    <>
+      {showNavbar && <Navbar />}
+      {children}
+    </>
+  );
+}

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -23,11 +23,16 @@ import {
   Info,
   Phone,
   LogIn,
-  UserPlus
+  UserPlus,
 } from "lucide-react"
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { useAuth } from "@/contexts/AuthContext"
 
-export function Navbar() {
+export default function Navbar() {
   const [open, setOpen] = useState(false)
+  const { user, logout } = useAuth();
+
   const pathname = usePathname()
 
   const isActive = (href: string) =>
@@ -57,7 +62,7 @@ export function Navbar() {
                   href="/blog"
                   className="text-sm font-medium text-gray-700 hover:text-emerald-700 hover:underline underline-offset-4 transition-colors"
                 >
-                  Blog
+                  Bài viết
                 </Link>
               </NavigationMenuItem>
               <NavigationMenuItem>
@@ -73,7 +78,7 @@ export function Navbar() {
                   href="/about"
                   className="text-sm font-medium text-gray-700 hover:text-emerald-700 hover:underline underline-offset-4 transition-colors"
                 >
-                  About
+                  Về chúng tôi
                 </Link>
               </NavigationMenuItem>
               <NavigationMenuItem>
@@ -81,20 +86,56 @@ export function Navbar() {
                   href="/about/contact"
                   className="text-sm font-medium text-gray-700 hover:text-emerald-700 hover:underline underline-offset-4 transition-colors"
                 >
-                  Contact
+                  Liên hệ
                 </Link>
               </NavigationMenuItem>
             </NavigationMenuList>
           </NavigationMenu>
 
-          <div className="flex gap-3">
-            <Button asChild className="rounded-full px-5 py-2">
-              <Link href="/login">Login</Link>
-            </Button>
-            <Button asChild className="rounded-full bg-emerald-600 px-5 py-2 hover:bg-emerald-700">
-              <Link href="/signup">Sign up</Link>
-            </Button>
-          </div>
+          {/* PHẦN HIỂN THỊ ĐỘNG */}
+          {user ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <div className="flex items-center gap-3">
+                  <Avatar>
+                    <AvatarImage src={user.avatar} alt={user.username} />
+                    <AvatarFallback>{user.username.charAt(0).toUpperCase()}</AvatarFallback>
+                  </Avatar>
+                  <span>{user.username}</span>
+                </div>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem asChild>
+                  <Link href={'/profile'}>
+                    <span>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+                      </svg>
+                    </span>
+                    Hồ sơ
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={logout}>
+                  <span>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 9V5.25A2.25 2.25 0 0 1 10.5 3h6a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 16.5 21h-6a2.25 2.25 0 0 1-2.25-2.25V15m-3 0-3-3m0 0 3-3m-3 3H15" />
+                    </svg>
+                  </span>
+                  Đăng xuất
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <div className="flex gap-3">
+              <Button asChild className="rounded-full px-5 py-2">
+                <Link href="/auth/login">Đăng nhập</Link>
+              </Button>
+              <Button asChild className="rounded-full bg-emerald-600 px-5 py-2 hover:bg-emerald-700">
+                <Link href="/auth/signup">Đăng ký</Link>
+              </Button>
+            </div>
+          )}
         </div>
 
         {/* Mobile navigation */}
@@ -139,7 +180,7 @@ export function Navbar() {
                   }`}
                 >
                   <Home className="h-5 w-5" />
-                  Home
+                  Trang chủ
                 </Link>
 
                 <Link
@@ -152,7 +193,7 @@ export function Navbar() {
                   }`}
                 >
                   <BookOpen className="h-5 w-5" />
-                  Blog
+                  Bài viết
                 </Link>
 
                 <Link
@@ -165,7 +206,7 @@ export function Navbar() {
                   }`}
                 >
                   <Info className="h-5 w-5" />
-                  About
+                  Về chúng tôi
                 </Link>
 
                 <Link
@@ -178,7 +219,7 @@ export function Navbar() {
                   }`}
                 >
                   <Phone className="h-5 w-5" />
-                  Contact
+                  Liên hệ
                 </Link>
               </nav>
 
@@ -186,17 +227,17 @@ export function Navbar() {
               <div className="sticky bottom-0 mt-2 border-t bg-white/80 backdrop-blur-md px-4 pt-3 pb-[max(env(safe-area-inset-bottom),12px)] space-y-3">
                 <SheetClose asChild>
                   <Button asChild variant="outline" className="w-full h-11 rounded-full text-base">
-                    <Link href="/login" className="flex items-center justify-center gap-2">
+                    <Link href="/auth/login" className="flex items-center justify-center gap-2">
                       <LogIn className="h-5 w-5" />
-                      Login
+                      Đăng nhập
                     </Link>
                   </Button>
                 </SheetClose>
                 <SheetClose asChild>
                   <Button asChild className="w-full h-11 rounded-full text-base bg-emerald-600 hover:bg-emerald-700">
-                    <Link href="/signup" className="flex items-center justify-center gap-2">
+                    <Link href="/auth/signup" className="flex items-center justify-center gap-2">
                       <UserPlus className="h-5 w-5" />
-                      Sign up
+                      Đăng ký
                     </Link>
                   </Button>
                 </SheetClose>

--- a/frontend/src/components/ui.tsx
+++ b/frontend/src/components/ui.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export const Card = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <div className={`bg-card text-card-foreground rounded-xl border shadow ${className}`}>{children}</div>
+);
+export const CardHeader = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <div className={`flex flex-col space-y-1.5 p-6 ${className}`}>{children}</div>
+);
+export const CardTitle = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <h3 className={`font-semibold tracking-tight text-2xl ${className}`}>{children}</h3>
+);
+export const CardDescription = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <p className={`text-sm text-muted-foreground ${className}`}>{children}</p>
+);
+export const CardContent = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <div className={`p-6 pt-0 ${className}`}>{children}</div>
+);
+export const CardFooter = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <div className={`flex items-center p-6 pt-0 ${className}`}>{children}</div>
+);
+
+export const Label = (props: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+  <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" {...props} />
+);
+
+export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(({ className, ...props }, ref) => (
+  <input
+    className={`flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+    ref={ref}
+    {...props}
+  />
+));
+Input.displayName = 'Input';
+
+export const Button = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(({ className, ...props }, ref) => (
+  <button
+    className={`inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 ${className}`}
+    ref={ref}
+    {...props}
+  />
+));
+Button.displayName = 'Button';

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn(
+        "relative flex size-8 shrink-0 overflow-hidden rounded-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "bg-muted flex size-full items-center justify-center rounded-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { apiLogout } from '@/app/auth/actions';
+import { getCurrentUser } from '@/lib/session';
+import React, { createContext, useState, useContext, useEffect, ReactNode, useCallback } from 'react';
+
+interface User {
+  id: number;
+  username: string;
+  email: string;
+  first_name?: string;
+  last_name?: string;
+  avatar?: string;
+}
+
+interface AuthContextType {
+  user: User | null;
+  isLoading: boolean;
+  logout: () => void;
+  checkUserSession: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const checkUserSession = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const userData = await getCurrentUser();
+      setUser(userData);
+    } catch (error) {
+      console.error("Failed to get user", error);
+      setUser(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    checkUserSession();
+  }, [checkUserSession]);
+
+  const logout = async () => {
+    try {
+      await apiLogout();
+    } catch (error) {
+      console.error("Failed to logout", error);
+    } finally {
+      setUser(null);
+    }
+  }
+
+  const value = { user, isLoading, logout, checkUserSession };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,24 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+async function fetchApi(endpoint: string, options: RequestInit = {}) {
+  const response = await fetch(`${API_URL}/${endpoint}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.non_field_errors?.[0] || 'An error occurred');
+  }
+
+  if (response.status === 204 || response.headers.get('Content-Length') === '0') {
+    return response;
+  }
+
+  return response.json();
+}
+
+export { fetchApi };

--- a/frontend/src/lib/session.ts
+++ b/frontend/src/lib/session.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import 'server-only'; // Đảm bảo file này chỉ chạy trên server
+import { cookies } from 'next/headers';
+import { fetchApi } from './api';
+
+// Định nghĩa kiểu dữ liệu cho User
+interface User {
+  id: number;
+  username: string;
+  email: string;
+  first_name?: string;
+  last_name?: string;
+  avatar?: string;
+}
+
+// Hàm lấy thông tin user từ cookie
+export async function getCurrentUser(): Promise<User | null> {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+
+  if (!accessToken) {
+    return null;
+  }
+
+  try {
+    const user = await fetchApi('api/users/me/', {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }) as User;
+
+    return user;
+
+  } catch (error) {
+    console.error('Failed to get current user:', error);
+    return null;
+  }
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname === '/agrihcmAdmin/login') {
+    return NextResponse.next();
+  }
+
+  const accessToken = request.cookies.get('accessToken')?.value;
+
+  if (!accessToken) {
+    return NextResponse.redirect(new URL('/agrihcmAdmin/login', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/agrihcmAdmin/:path*'],
+};


### PR DESCRIPTION
**Frontend:**

- When a user is not signed in or authenticated, the navbar will show the login and register buttons:

<img width="1347" height="77" alt="a1" src="https://github.com/user-attachments/assets/2461dfe0-4192-4ea9-aeb6-5dc5890ac20d" />
<hr>

- When a user clicks the sign-up (đăng ký) button, the following page will display:

<img width="1382" height="780" alt="a2" src="https://github.com/user-attachments/assets/72a885af-e7ab-446a-9fb0-d79daf910c9d" />
<hr>

- When a user clicks the sign-in (đăng nhập) button, the following page will display:

<img width="1435" height="692" alt="a3" src="https://github.com/user-attachments/assets/c7d82d7e-a980-4f59-ae73-ea17db708314" />
<hr>

- After a user is signed in, the navbar will display the user's avatar and username:

<img width="480" height="55" alt="a4" src="https://github.com/user-attachments/assets/d8e40e6f-b020-4476-8412-e6f41e6ce8b5" />
<hr>

- When an authenticated (after successfully signing in) user hovers the cursor over the user's info area in the navbar, the dropdown menu will show:

<img width="257" height="156" alt="a5" src="https://github.com/user-attachments/assets/afb33537-c107-46e4-a3c1-ffdd6ac75362" />
<hr>

- The sign-in page for ADMIN does not have the navbar as a regular user will see, it looks like this:

<img width="1619" height="834" alt="image" src="https://github.com/user-attachments/assets/1776ff3a-0081-42f2-bd3d-474f9ed7d24f" />
<hr>

- After an admin signs in, the temporary administration page will show:

<img width="738" height="273" alt="image" src="https://github.com/user-attachments/assets/a601fc86-556e-4d94-98c0-95ad5daf068c" />
<hr>